### PR TITLE
Bug/sprint8/21654

### DIFF
--- a/lib/screens/messages/list_messages.dart
+++ b/lib/screens/messages/list_messages.dart
@@ -529,10 +529,10 @@ class _ListMessageState extends State<ListMessages> {
                   );
                 } else {
                   return Container(
-                    padding: EdgeInsets.all(screenHeight * 2.5),
+                    padding: EdgeInsets.all(screenHeight * 4),
                     margin: EdgeInsets.only(top: screenHeight * 2.5),
                     child: AutoSizeText(
-                      "Não existe notificações para as categorias selecioandas.",
+                      "Não foi encontrada nenhuma mensagem para este filtro",
                       textAlign: TextAlign.center,
                       minFontSize: 14,
                       maxFontSize: 16,

--- a/lib/screens/messages/list_messages.dart
+++ b/lib/screens/messages/list_messages.dart
@@ -507,16 +507,32 @@ class _ListMessageState extends State<ListMessages> {
                 ],
               ),
               Observer(builder: (context) {
+                // !turmaCheck && !smeCheck && !ueCheck
                 if (_messagesController.filteredList != null &&
                     _messagesController.filteredList.isNotEmpty) {
                   return _listCardsMessages(_messagesController.filteredList,
                       context, screenHeight, token);
-                } else {
+                } else if (!turmaCheck && !smeCheck && !ueCheck) {
                   return Container(
                     padding: EdgeInsets.all(screenHeight * 2.5),
                     margin: EdgeInsets.only(top: screenHeight * 2.5),
                     child: AutoSizeText(
                       "Selecione uma categoria para visualizar as mensagens.",
+                      textAlign: TextAlign.center,
+                      minFontSize: 14,
+                      maxFontSize: 16,
+                      style: TextStyle(
+                        color: Color(0xff727374),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  );
+                } else {
+                  return Container(
+                    padding: EdgeInsets.all(screenHeight * 2.5),
+                    margin: EdgeInsets.only(top: screenHeight * 2.5),
+                    child: AutoSizeText(
+                      "Não existe notificações para as categorias selecioandas.",
                       textAlign: TextAlign.center,
                       minFontSize: 14,
                       maxFontSize: 16,


### PR DESCRIPTION
Quando o filtro selecionado não encontra nenhuma mensagem deverá ser ajustada a mensagem que é apresentada para o usuário, pois atualmente está indicando que ele precisa selecionar um filtro.
